### PR TITLE
Fix: update-initramfs in chroot + unmount partitions before labelling disk

### DIFF
--- a/core/disk.go
+++ b/core/disk.go
@@ -126,6 +126,12 @@ func (disk *Disk) Update() error {
 func (disk *Disk) LabelDisk(label DiskLabel) error {
 	labelDiskCmd := "parted -s %s mklabel %s"
 
+	for _, part := range disk.Partitions {
+		if err := part.UmountPartition(); err != nil {
+			return fmt.Errorf("Failed to unmount partition %s: %s", part.Path, err)
+		}
+	}
+
 	err := RunCommand(fmt.Sprintf(labelDiskCmd, disk.Path, label))
 	if err != nil {
 		return fmt.Errorf("Failed to label disk: %s", err)

--- a/core/filesystem.go
+++ b/core/filesystem.go
@@ -93,11 +93,38 @@ func GenFstab(targetRoot string, entries [][]string) error {
 }
 
 func UpdateInitramfs(root string) error {
+	// Setup mountpoints
+	if err := RunCommand(fmt.Sprintf("mount --bind /dev %s/dev", root)); err != nil {
+		return fmt.Errorf("Error mounting /dev to chroot: %s", err)
+	}
+	if err := RunCommand(fmt.Sprintf("mount --bind /dev/pts %s/dev/pts", root)); err != nil {
+		return fmt.Errorf("Error mounting /dev/pts to chroot: %s", err)
+	}
+	if err := RunCommand(fmt.Sprintf("mount --bind /proc %s/proc", root)); err != nil {
+		return fmt.Errorf("Error mounting /proc to chroot: %s", err)
+	}
+	if err := RunCommand(fmt.Sprintf("mount --bind /sys %s/sys", root)); err != nil {
+		return fmt.Errorf("Error mounting /sys to chroot: %s", err)
+	}
+
 	updInitramfsCmd := "update-initramfs -c -k all"
 
 	err := RunInChroot(root, updInitramfsCmd)
 	if err != nil {
 		return fmt.Errorf("Failed to run update-initramfs command: %s", err)
+	}
+
+	if err := RunCommand(fmt.Sprintf("umount %s/dev/pts", root)); err != nil {
+		return fmt.Errorf("Error unmounting /dev/pts fron chroot: %s", err)
+	}
+	if err := RunCommand(fmt.Sprintf("umount %s/dev", root)); err != nil {
+		return fmt.Errorf("Error unmounting /dev from chroot: %s", err)
+	}
+	if err := RunCommand(fmt.Sprintf("umount %s/proc", root)); err != nil {
+		return fmt.Errorf("Error unmounting /proc from chroot: %s", err)
+	}
+	if err := RunCommand(fmt.Sprintf("umount %s/sys", root)); err != nil {
+		return fmt.Errorf("Error unmounting /sys from chroot: %s", err)
 	}
 
 	return nil

--- a/core/partition.go
+++ b/core/partition.go
@@ -88,7 +88,7 @@ func (part *Partition) IsMounted() (bool, error) {
 		return false, fmt.Errorf("Failed to check if partition is mounted: %s", err)
 	}
 
-	mounts, err := strconv.Atoi(string(output))
+	mounts, err := strconv.Atoi(strings.TrimSpace(string(output)))
 	if err != nil {
 		return false, fmt.Errorf("Failed to convert str to int: %s", err)
 	}
@@ -318,4 +318,3 @@ func (part *Partition) SetLabel(label string) error {
 
 	return nil
 }
-

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+albius (0.2.9) unstable; urgency=critical
+
+  * Fix: Unmount paths after updating initramfs
+  * Unmount all partitions before formatting disk
+
+ -- Mateus Melchiades <matbme@duck.com>  Sat, 20 Aug 2023 13:33:00 -0300
+
+albius (0.2.8) unstable; urgency=critical
+
+  * Mount required paths to chroot before updating initramfs
+
+ -- Mateus Melchiades <matbme@duck.com>  Sat, 19 Aug 2023 13:23:00 -0300
+
 albius (0.2.7) unstable; urgency=critical
 
   * Clean storage tmp directory instead of deleting it

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+albius (0.2.10) unstable; urgency=critical
+
+  * Fix: Fix incorrect parsing of IsMounted function
+
+ -- Mateus Melchiades <matbme@duck.com>  Sat, 22 Aug 2023 08:39:00 -0300
+
 albius (0.2.9) unstable; urgency=critical
 
   * Fix: Unmount paths after updating initramfs

--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,1 @@
-albius_0.2.7_source.buildinfo devel extra
+albius_0.2.9_source.buildinfo devel extra

--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,1 @@
-albius_0.2.9_source.buildinfo devel extra
+albius_0.2.10_source.buildinfo devel extra


### PR DESCRIPTION
This PR adds two fixes for different operations:

The first fix is related to the `update-initramfs` operation, where the proper mounts were missing for the operation to complete without errors.

The second fix is related to not unmounting a disk's partition before running operations on it. Albius will now try to unmount all partitions before running the `label` operation.