### PR TITLE
LUKS on LVM

### DIFF
--- a/RECIPE.md
+++ b/RECIPE.md
@@ -190,6 +190,16 @@ Same as `format`, but formats an LVM logical volume.
 - *FsType* (`string`): The filesystem for the partition. Can be either `btrfs`, `ext[2,3,4]`, `linux-swap`, `ntfs`\*, `reiserfs`\*, `udf`\*, or `xfs`\*.
 - *Label* (optional `string`): An optional filesystem label. If not given, no label will be set.
 
+### lvm-luks-format
+
+Same as `luks-format`, but formats an LVM logical volume.
+
+**Accepts**:
+- *Name* (`string`): Thin logical volume name (in format `vg_name/lv_name`).
+- *FsType* (`string`): The filesystem for the partition. Can be either `btrfs`, `ext[2,3,4]`, `linux-swap`, `ntfs`\*, `reiserfs`\*, `udf`\*, or `xfs`\*.
+- *Password* (`string`): The password used to encrypt the volume.
+- *Label* (optional `string`): An optional filesystem label. If not given, no label will be set.
+
 --- 
 
 ## Post-Installation 

--- a/core/recipe.go
+++ b/core/recipe.go
@@ -566,7 +566,7 @@ func runSetupOperation(diskLabel, operation string, args []interface{}) error {
 		for uuid == "" {
 			uuid, _ = dummyPart.GetUUID()
 		}
-		err = LUKSMakeFs(&dummyPart)
+		err = MakeFs(&dummyPart)
 		if err != nil {
 			return fmt.Errorf("failed to execute operation %s: %s", operation, err)
 		}

--- a/core/recipe.go
+++ b/core/recipe.go
@@ -125,10 +125,7 @@ func runSetupOperation(diskLabel, operation string, args []interface{}) error {
 			// UUID, so we loop until it gives us one
 			uuid := ""
 			for uuid == "" {
-				uuid, err = part.GetUUID()
-			}
-			if err != nil {
-				return fmt.Errorf("failed to execute operation %s: %s", operation, err)
+				uuid, _ = part.GetUUID()
 			}
 			err = LuksOpen(part, fmt.Sprintf("luks-%s", uuid), luksPassword)
 			if err != nil {
@@ -270,6 +267,12 @@ func runSetupOperation(diskLabel, operation string, args []interface{}) error {
 		err = LuksFormat(&part, password)
 		if err != nil {
 			return fmt.Errorf("failed to execute operation %s: %s", operation, err)
+		}
+		// lsblk seems to take a few milliseconds to update the partition's
+		// UUID, so we loop until it gives us one
+		uuid := ""
+		for uuid == "" {
+			uuid, _ = part.GetUUID()
 		}
 		err = LUKSMakeFs(&part)
 		if err != nil {
@@ -556,6 +559,12 @@ func runSetupOperation(diskLabel, operation string, args []interface{}) error {
 		err = LuksFormat(&dummyPart, password)
 		if err != nil {
 			return fmt.Errorf("failed to execute operation %s: %s", operation, err)
+		}
+		// lsblk seems to take a few milliseconds to update the partition's
+		// UUID, so we loop until it gives us one
+		uuid := ""
+		for uuid == "" {
+			uuid, _ = dummyPart.GetUUID()
 		}
 		err = LUKSMakeFs(&dummyPart)
 		if err != nil {

--- a/core/recipe.go
+++ b/core/recipe.go
@@ -566,13 +566,17 @@ func runSetupOperation(diskLabel, operation string, args []interface{}) error {
 		for uuid == "" {
 			uuid, _ = dummyPart.GetUUID()
 		}
-		err = MakeFs(&dummyPart)
+		err = LuksOpen(&dummyPart, fmt.Sprintf("luks-%s", uuid), password)
+		if err != nil {
+			return fmt.Errorf("failed to execute operation %s: %s", operation, err)
+		}
+		err = LUKSMakeFs(&dummyPart)
 		if err != nil {
 			return fmt.Errorf("failed to execute operation %s: %s", operation, err)
 		}
 		if len(args) == 4 {
 			label := args[3].(string)
-			err := dummyPart.SetLabel(label)
+			err := LUKSSetLabel(&dummyPart, label)
 			if err != nil {
 				return fmt.Errorf("failed to execute operation %s: %s", operation, err)
 			}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+albius (0.3.1) unstable; urgency=critical
+
+  * LUKS on LVM support
+
+ -- Mateus Melchiades <matbme@duck.com>  Sat, 05 Nov 2023 11:47:00 -0300
+
 albius (0.3.0) unstable; urgency=critical
 
   * LVM support

--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,1 @@
-albius_0.3.0_source.buildinfo devel extra
+albius_0.3.1_source.buildinfo devel extra


### PR DESCRIPTION
This PR adds support for configuring LUKS on LVM with the `lvm-luks-format` command, which creates a new encrypted filesystem on top of an existing LV.