### PR TITLE
feat/ci: update workflows

### DIFF
--- a/.github/workflows/deb-build.yml
+++ b/.github/workflows/deb-build.yml
@@ -30,7 +30,7 @@ jobs:
         dpkg-buildpackage --no-sign
         mv ../*.deb ../albius.deb
 
-    - uses: softprops/action-gh-release@v0.1.15
+    - uses: softprops/action-gh-release@v1
       with:
         token: "${{ secrets.GITHUB_TOKEN }}"
         tag_name: "continuous"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21
 


### PR DESCRIPTION
## Changes

- Bump `actions/setup-go` to `v5` (Node 20).
- Update `softprops/action-gh-release` to use standard `v1` specification instead of specifying version.