### PR TITLE
removes go as runtime dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,6 @@ Package: albius
 Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         golang-go,
          lvm2,
          parted
 Built-Using: ${misc:Built-Using}


### PR DESCRIPTION
Go is only used to build Albius, it should not be necessary for running the program.